### PR TITLE
Add endpoint options

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,19 @@ documentation for allowed values.
 
 [Aws::SecretsManager::Client#initialize]: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SecretsManager/Client.html#initialize-instance_method
 
+#### Endpoint
+
+It is possible to configure the AWS SDK endpoint by adding a
+`options.endpoint` hash. Its value is passed to the AWS SDK with
+minimal sanity checking. See the [Aws::SecretsManager::Client#initialize]
+documentation for allowed values.
+
+[AWS PrivateLink] is a use case. Which is very convenience to privately connect
+your VPC to supported AWS services, services hosted by other AWS accounts
+(VPC endpoint services), and supported AWS Marketplace partner services.
+
+[AWS PrivateLink]: https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-overview.html
+
 #### StatsD
 
 Setting `options.statsd: true` will enable some statsd reporting using

--- a/lib/puppet/functions/hiera_aws_secretsmanager.rb
+++ b/lib/puppet/functions/hiera_aws_secretsmanager.rb
@@ -85,6 +85,7 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
   def smclient_options
     smclient_options = {region: @options['region']}
     smclient_options.merge!(retry_options)
+    smclient_options.merge!(endpoint_options)
     @context.explain { "Aws::SecretsManager::Client options: #{smclient_options}" }
     smclient_options
   end
@@ -105,6 +106,23 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
     ]
 
     @options['retries']
+      .select { |opt, _| allowed_opts.member?(opt) }
+      .transform_keys!(&:to_sym)
+  end
+
+  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SecretsManager/Client.html#initialize-instance_method
+  def endpoint_options
+    return {} unless @options['endpoint']
+
+    allowed_opts = %w[
+      endpoint
+      endpoint_cache_max_entries
+      endpoint_cache_max_threads
+      endpoint_cache_poll_interval
+      endpoint_discovery
+    ]
+
+    @options['endpoint']
       .select { |opt, _| allowed_opts.member?(opt) }
       .transform_keys!(&:to_sym)
   end

--- a/spec/functions/lookup_key_spec.rb
+++ b/spec/functions/lookup_key_spec.rb
@@ -19,6 +19,11 @@ describe :hiera_aws_secretsmanager do
       'retries' => {
         'retry_mode' => 'adaptive',
         'max_attempts' => 10,
+      },
+      'endpoint' => {
+        'endpoint' => 'https://my.private.endpoint.aws.com',
+        'endpoint_cache_max_threads' => 5,
+        'endpoint_discovery' => false,
       }
     }
   }


### PR DESCRIPTION
This will allow to configure the endpoint to be used or different endpoint options.

[AWS PrivateLink] is a good use case. Which is very convenience to privately connect your VPC to supported AWS services, services hosted by other AWS accounts (VPC endpoint services), and supported AWS Marketplace partner services.

[AWS PrivateLink]: https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-overview.html